### PR TITLE
fixed url

### DIFF
--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -134,7 +134,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      ncBackendUrl:  process.env.NC_BACKEND_URL || 'http://localhost:3333/',
+      ncBackendUrl:  process.env.NC_BACKEND_URL || '',
       env: 'production',
       maxPageDesignerTableRows: 100,
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated frontend configuration to remove the default localhost backend URL. If NC_BACKEND_URL is not set, no fallback is applied.
  - Impact: Deployments must explicitly configure the backend URL; otherwise, the app may not connect to an API. This prevents unintended calls to a localhost backend in production.
  - For local development, ensure NC_BACKEND_URL is set to your backend address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->